### PR TITLE
Implemented PBKDF2-HMAC-SHA256 as the KDF with option for ether 600k …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-RM := rm -rf
 COMPILER_PREFIX := riscv-none-elf
 
 ifeq ($(COMPILER_PREFIX),riscv-none-embed)
@@ -14,6 +13,7 @@ endif
 # Define option(s) defined in pre-processor compiler option(s)
 DEFINE_OPTS = -DMSC_DEVICE
 AES_MODE ?= XTS
+KDF_ROUNDS ?= 100000
 
 ifeq ($(AES_MODE),CTR)
 AES_SRCS = $(USER_DIR)/phantomdrive_aes_ctr.c
@@ -22,6 +22,16 @@ AES_SRCS = $(USER_DIR)/phantomdrive_aes_xts.c
 else
 $(error AES_MODE must be CTR or XTS)
 endif
+
+ifeq ($(KDF_ROUNDS),100000)
+KDF_MODE = 100K
+else ifeq ($(KDF_ROUNDS),600000)
+KDF_MODE = 600K
+else
+$(error KDF_ROUNDS must be 100000 or 600000)
+endif
+
+DEFINE_OPTS += -DKDF_ROUNDS=$(KDF_ROUNDS)U
 
 # Add UART debugging.
 ifeq ($(UART),1)
@@ -34,7 +44,7 @@ OPTIM_OPTS = -O3
 #DEBUG = -g
 DEBUG =
 
-BUILD_DIR = ./build/$(AES_MODE)
+BUILD_DIR = ./build/$(AES_MODE)_$(KDF_MODE)
 
 PROJECT = $(BUILD_DIR)/Phantomdrive_MSC
 
@@ -158,13 +168,15 @@ $(PROJECT).siz: $(PROJECT).elf
 	$(COMPILER_PREFIX)-size --format=berkeley "$(PROJECT).elf"
 	@echo ' '
 
+$(PROJECT).map: $(PROJECT).elf
+	@test -f "$@"
+
 flash: all
 	sudo ./wch-ch56x-isp/wch-ch56x-isp -d=off
 	sudo ./wch-ch56x-isp/wch-ch56x-isp -f "$(PROJECT).bin"
 
 # Other Targets
 clean:
-	-$(RM) $(OBJS) $(DEPS) $(SECONDARY_OUTPUTS) $(PROJECT).elf
-	-@echo ' '
+	rm -rf ./build
 
 .PHONY: all clean dependents

--- a/readme.md
+++ b/readme.md
@@ -40,18 +40,25 @@ make UART=1 # Enable UART
 
 ## Build and Flashing the project
 
-Flashing requires the AES mode to be selected explicitly in the same `make` invocation.
+The AES mode and PBKDF2 iteration count can be selected independently. Supported
+KDF values are `100000` and `600000`; 100,000 is the default.
 
 ``` bash
 # Remove flash drive
 # While holding boot button, plug in
 
-# Build and flash AES-XTS firmware
-make AES_MODE=XTS flash
+# Build and flash AES-XTS firmware with 600,000 PBKDF2 iterations
+make AES_MODE=XTS KDF_ROUNDS=600000 flash
 
-# Or build and flash AES-CTR firmware
-make AES_MODE=CTR flash
+# Or build and flash AES-CTR firmware with 100,000 iterations
+make AES_MODE=CTR KDF_ROUNDS=100000 flash
+
+# Build all four AES/KDF combinations
+./release.sh
 ```
+
+The four builds are written to `build/CTR_100K`, `build/CTR_600K`,
+`build/XTS_100K`, and `build/XTS_600K`.
 
 ## Unlocking Drive
 ``` bash
@@ -67,6 +74,9 @@ sudo echo "password:YourPasswordHere13245" > /mnt/unlock.txt
 
 This code has not been professionally audited. Treat Phantomdrive as an experimental open source hardware/firmware project rather than a formally reviewed security product. The current level of validation is described in the [test README](test/readme.md). I am not responsible for loss of data, security incidents, or other damage resulting from use of this project.
 
-The encrypted area currently uses AES-256-XTS. This is an on-disk format change from the previous AES-CTR implementation, so data written by older firmware will not decrypt correctly without migration or reformatting.
+The encrypted area can use AES-256-CTR or AES-256-XTS, with keys derived using
+PBKDF2-HMAC-SHA256 and either 100,000 or 600,000 iterations. AES mode and KDF
+iteration count affect the on-disk format, so firmware built with different
+settings cannot decrypt the same data without migration or reformatting.
 
 Unlock detection is also content-based. While the device is locked, any write data containing the string `password:` can be interpreted as an unlock attempt; the file does not need to be named `unlock.txt`.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+make clean
+make AES_MODE=CTR KDF_ROUNDS=100000
+make AES_MODE=CTR KDF_ROUNDS=600000
+make AES_MODE=XTS KDF_ROUNDS=100000
+make AES_MODE=XTS KDF_ROUNDS=600000

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -161,27 +161,82 @@ void sha256(const uint8_t *data, size_t len, uint8_t hash_out[32])
 }
 
 /*****************************************************************************
- * KDF: Iterated SHA-256 key derivation
- * key = SHA256(salt || password), then 100000x key = SHA256(key || password)
+ * PBKDF2-HMAC-SHA256 key derivation (RFC 8018)
  *****************************************************************************/
-#define KDF_ROUNDS 100000
+#define SHA256_BLOCK_SIZE 64
+#define SHA256_DIGEST_SIZE 32
+
+static void hmac_sha256_init(const uint8_t *key, size_t key_len,
+                             uint32_t inner_state[8],
+                             uint32_t outer_state[8])
+{
+	uint8_t key_block[SHA256_BLOCK_SIZE] = {0};
+	sha256_ctx_t ctx;
+
+	if (key_len > SHA256_BLOCK_SIZE) {
+		sha256(key, key_len, key_block);
+	} else {
+		memcpy(key_block, key, key_len);
+	}
+
+	for (size_t i = 0; i < SHA256_BLOCK_SIZE; i++)
+		key_block[i] ^= 0x36;
+	sha256_init(&ctx);
+	sha256_update(&ctx, key_block, sizeof(key_block));
+	memcpy(inner_state, ctx.state, sizeof(ctx.state));
+
+	for (size_t i = 0; i < SHA256_BLOCK_SIZE; i++)
+		key_block[i] ^= 0x36 ^ 0x5c;
+	sha256_init(&ctx);
+	sha256_update(&ctx, key_block, sizeof(key_block));
+	memcpy(outer_state, ctx.state, sizeof(ctx.state));
+}
+
+static void sha256_restore_hmac_state(sha256_ctx_t *ctx,
+                                      const uint32_t state[8])
+{
+	memcpy(ctx->state, state, sizeof(ctx->state));
+	ctx->buf_len = 0;
+	ctx->total_len = SHA256_BLOCK_SIZE;
+}
+
+static void hmac_sha256(const uint32_t inner_state[8],
+                        const uint32_t outer_state[8],
+                        const uint8_t *data, size_t data_len,
+                        const uint8_t *suffix, size_t suffix_len,
+                        uint8_t hash_out[SHA256_DIGEST_SIZE])
+{
+	sha256_ctx_t ctx;
+	uint8_t inner_hash[SHA256_DIGEST_SIZE];
+
+	sha256_restore_hmac_state(&ctx, inner_state);
+	sha256_update(&ctx, data, data_len);
+	if (suffix_len > 0)
+		sha256_update(&ctx, suffix, suffix_len);
+	sha256_final(&ctx, inner_hash);
+
+	sha256_restore_hmac_state(&ctx, outer_state);
+	sha256_update(&ctx, inner_hash, sizeof(inner_hash));
+	sha256_final(&ctx, hash_out);
+}
 
 void derive_key(const uint8_t *password, size_t pw_len, uint8_t kdf_salt[KDF_SALT_SIZE], uint8_t key_out[32])
 {
-	sha256_ctx_t ctx;
-	int i;
+	uint32_t inner_state[8];
+	uint32_t outer_state[8];
+	uint8_t block_index[4] = {0, 0, 0, 1};
+	uint8_t u[SHA256_DIGEST_SIZE];
 
-	/* Round 0: key = SHA256(salt || password) */
-	sha256_init(&ctx);
-	sha256_update(&ctx, kdf_salt, KDF_SALT_SIZE);
-	sha256_update(&ctx, password, pw_len);
-	sha256_final(&ctx, key_out);
+	hmac_sha256_init(password, pw_len, inner_state, outer_state);
+	hmac_sha256(inner_state, outer_state,
+	            kdf_salt, KDF_SALT_SIZE,
+	            block_index, sizeof(block_index), u);
+	memcpy(key_out, u, sizeof(u));
 
-	/* Rounds 1..KDF_ROUNDS: key = SHA256(key || password) */
-	for (i = 0; i < KDF_ROUNDS; i++) {
-		sha256_init(&ctx);
-		sha256_update(&ctx, key_out, 32);
-		sha256_update(&ctx, password, pw_len);
-		sha256_final(&ctx, key_out);
+	for (uint32_t round = 1; round < KDF_ROUNDS; round++) {
+		hmac_sha256(inner_state, outer_state,
+		            u, sizeof(u), NULL, 0, u);
+		for (size_t i = 0; i < sizeof(u); i++)
+			key_out[i] ^= u[i];
 	}
 }

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -4,12 +4,16 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifndef KDF_ROUNDS
+#define KDF_ROUNDS 100000U
+#endif
+
 #define KDF_SALT_SIZE 8
 
 /* SHA-256: compute hash of data into 32-byte output */
 void sha256(const uint8_t *data, size_t len, uint8_t hash_out[32]);
 
-/* KDF: derive 32-byte AES-256 key from password, iterated SHA-256 and salt */
+/* KDF: derive 32-byte AES-256 key using PBKDF2-HMAC-SHA256*/
 void derive_key(const uint8_t *password, size_t pw_len, uint8_t kdf_salt[KDF_SALT_SIZE], uint8_t key_out[32]);
 
 #endif /* CRYPTO_H_ */

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,31 +1,35 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -O2
 LDLIBS = -lcrypto -lssl
+BUILD_DIR = build
+TESTS = sha256_test pbkdf2_test ctr_test xts_test
 
-all: sha256_test ctr_test xts_test
+all: $(TESTS)
 
-sha256_test: sha256_test.o crypto.o
+$(TESTS): %: $(BUILD_DIR)/%
+
+$(BUILD_DIR)/sha256_test: $(BUILD_DIR)/sha256_test.o $(BUILD_DIR)/crypto.o
 	$(CC) $^ $(LDLIBS) -o $@
 
-ctr_test: ctr_test.o crypto.o
+$(BUILD_DIR)/pbkdf2_test: $(BUILD_DIR)/pbkdf2_test.o $(BUILD_DIR)/crypto.o
 	$(CC) $^ $(LDLIBS) -o $@
 
-xts_test: xts_test.o crypto.o
+$(BUILD_DIR)/ctr_test: $(BUILD_DIR)/ctr_test.o $(BUILD_DIR)/crypto.o
 	$(CC) $^ $(LDLIBS) -o $@
 
-sha256_test.o: sha256_test.c
+$(BUILD_DIR)/xts_test: $(BUILD_DIR)/xts_test.o $(BUILD_DIR)/crypto.o
+	$(CC) $^ $(LDLIBS) -o $@
+
+$(BUILD_DIR)/%.o: %.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-ctr_test.o: ctr_test.c
+$(BUILD_DIR)/crypto.o: ../src/crypto.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-xts_test.o: xts_test.c
-	$(CC) $(CFLAGS) -c $< -o $@
-
-crypto.o: ../src/crypto.c
-	$(CC) $(CFLAGS) -c $< -o $@
+$(BUILD_DIR):
+	mkdir -p $@
 
 clean:
-	rm -f sha256_test ctr_test xts_test *.o
+	rm -rf $(BUILD_DIR)
 
-.PHONY: all clean
+.PHONY: all clean $(TESTS)

--- a/test/ctr_test.c
+++ b/test/ctr_test.c
@@ -187,8 +187,14 @@ int main(int argc, char *argv[])
 		0x34, 0xfc, 0x1f, 0xa7, 0x14, 0x54, 0x67, 0xf7,
 	};
 	uint8_t key[KEY_SIZE];
+	size_t pw_len = sizeof(password) - 1;
 
-	derive_key(password, sizeof(password) - 1, salt, key);
+	if (PKCS5_PBKDF2_HMAC((const char *)password, pw_len,
+	                      salt, KDF_SALT_SIZE, KDF_ROUNDS,
+	                      EVP_sha256(), sizeof(key), key) != 1) {
+		fprintf(stderr, "OpenSSL PBKDF2 failed\n");
+		return EXIT_FAILURE;
+	}
 
 	printf("Key: ");
 	for (size_t i = 0; i < KEY_SIZE; i++)

--- a/test/pbkdf2_test.c
+++ b/test/pbkdf2_test.c
@@ -1,0 +1,48 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <openssl/evp.h>
+
+#include "../src/crypto.h"
+
+#define KEY_SIZE 32
+
+static bool test_pbkdf2(const uint8_t *password, size_t pw_len,
+                        uint8_t salt[KDF_SALT_SIZE])
+{
+	uint8_t expected[KEY_SIZE];
+	uint8_t actual[KEY_SIZE];
+
+	if (PKCS5_PBKDF2_HMAC((const char *)password, pw_len,
+	                      salt, KDF_SALT_SIZE, KDF_ROUNDS,
+	                      EVP_sha256(), sizeof(expected), expected) != 1) {
+		fprintf(stderr, "OpenSSL PBKDF2 failed\n");
+		return false;
+	}
+
+	derive_key(password, pw_len, salt, actual);
+	if (memcmp(actual, expected, sizeof(actual)) != 0) {
+		fprintf(stderr, "PBKDF2-SHA256 test failed\n");
+		return false;
+	}
+
+	return true;
+}
+
+int main(void)
+{
+	const uint8_t password[] = "correct horse battery staple";
+	uint8_t long_password[80];
+	uint8_t salt[KDF_SALT_SIZE] = {
+		0x34, 0xfc, 0x1f, 0xa7, 0x14, 0x54, 0x67, 0xf7
+	};
+
+	memset(long_password, 'p', sizeof(long_password));
+	if (!test_pbkdf2(password, sizeof(password) - 1, salt) ||
+	    !test_pbkdf2(long_password, sizeof(long_password), salt))
+		return 1;
+
+	printf("PBKDF2-SHA256 test passed\n");
+	return 0;
+}

--- a/test/readme.md
+++ b/test/readme.md
@@ -21,8 +21,18 @@ These are tests to verify the cryptographic functions are working.
 ``` bash
 cd test
 make sha256_test # To test the sha256 function
-./sha256_test
+./build/sha256_test
 ```
+
+### PBKDF2-HMAC-SHA256 implementation
+
+``` bash
+cd test
+make pbkdf2_test
+./build/pbkdf2_test
+```
+
+This compares the project KDF at 600,000 iterations against OpenSSL.
 
 ### AES-CTR Test
 
@@ -44,7 +54,7 @@ uint8_t salt[KDF_SALT_SIZE] = {0x34, 0xfc, 0x1f, 0xa7, 0x14, 0x54, 0x67, 0xf7};
 
 ``` bash
 make ctr_test
-sudo ./ctr_test /dev/sdX
+sudo ./build/ctr_test /dev/sdX
 sudo losetup -Pf --show unencrypted.blob
 sudo mount /dev/loop0p1 /mnt/
 # Verify your files. You can use f3 if you like.
@@ -62,7 +72,7 @@ Set the password and device salt in `xts_test.c`, then decrypt the raw SD card:
 ``` bash
 cd test
 make xts_test
-sudo ./xts_test /dev/sdX
+sudo ./build/xts_test /dev/sdX
 sudo losetup -Pf --show unencrypted.blob
 sudo mount /dev/loop0p1 /mnt/
 ```

--- a/test/xts_test.c
+++ b/test/xts_test.c
@@ -220,15 +220,26 @@ int main(int argc, char *argv[])
 	};
 	uint8_t data_key[KEY_SIZE];
 	uint8_t tweak_key[KEY_SIZE];
+	size_t pw_len = sizeof(password) - 1;
 
 	if (argc != 2) {
 		fprintf(stderr, "Usage: %s /dev/sdX\n", argv[0]);
 		return 1;
 	}
 
-	derive_key(password, sizeof(password) - 1, salt, data_key);
+	if (PKCS5_PBKDF2_HMAC((const char *)password, pw_len,
+	                      salt, KDF_SALT_SIZE, KDF_ROUNDS,
+	                      EVP_sha256(), sizeof(data_key), data_key) != 1) {
+		fprintf(stderr, "OpenSSL PBKDF2 failed for data key\n");
+		return 1;
+	}
 	salt[0]++;
-	derive_key(password, sizeof(password) - 1, salt, tweak_key);
+	if (PKCS5_PBKDF2_HMAC((const char *)password, pw_len,
+	                      salt, KDF_SALT_SIZE, KDF_ROUNDS,
+	                      EVP_sha256(), sizeof(tweak_key), tweak_key) != 1) {
+		fprintf(stderr, "OpenSSL PBKDF2 failed for tweak key\n");
+		return 1;
+	}
 
 	return decrypt_device(argv[1], data_key, tweak_key);
 }


### PR DESCRIPTION
…rounds or 100k rounds. Added tests to verify the output against openSSL's implementation. anything else in this commit?

Fixes #3 and #1 

## Tests

``` bash
machinehum@t14s:test$ ./build/pbkdf2_test
PBKDF2-SHA256 test passed
machinehum@t14s:test$
```

``` bash
machinehum@t14s:test$ sudo ./build/xts_test /dev/sdg
Valid MBR signature found
machinehum@t14s:test$ sudo losetup -Pf --show unencrypted.blob # Setup
/dev/loop0
machinehum@t14s:test$ lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
loop0         7:0    0  21.5G  0 loop
└─loop0p1   259:3    0  21.5G  0 part
sdg           8:96   1  29.5G  0 disk
└─sdg1        8:97   1     8G  0 part
nvme0n1     259:0    0 476.9G  0 disk
├─nvme0n1p1 259:1    0     1G  0 part /boot
└─nvme0n1p2 259:2    0 475.9G  0 part /
machinehum@t14s:test$ sudo mount /dev/loop0p1 /mnt/
machinehum@t14s:test$ ls /mnt/
1.h2w  2.h2w  3.h2w  lost+found
machinehum@t14s:test$ sudo f3read /mnt/
F3 read 10.0
Copyright (C) 2010 Digirati Internet LTDA.
This is free software; see the source for copying conditions.

                  SECTORS      ok/corrupted/changed/overwritten
Validating file 1.h2w ... 2097152/        0/      0/      0 Avg: 922.98 MB/s
	Min: 7.00 MB/s, Max: 1.82 GB/s, 18 samples
Validating file 2.h2w ... 2097152/        0/      0/      0 Avg: 961.10 MB/s
Validating file 3.h2w ... 2097152/        0/      0/      0 Avg: 1.17 GB/s

  Data OK: 3.00 GB (6291456 sectors)
Data LOST: 0.00 Bytes (0 sectors)
	       Corrupted: 0.00 Bytes (0 sectors)
	Slightly changed: 0.00 Bytes (0 sectors)
	     Overwritten: 0.00 Bytes (0 sectors)
Average sequential read speed: 1012.57 MB/s (6291456 sectors / 3.03s)
```